### PR TITLE
Add FastAPI web interface and robot control endpoints

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Backend package for FastAPI server

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,66 @@
+from datetime import timedelta, datetime
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from . import models, schemas, database
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+SECRET_KEY = "CHANGE_ME"
+ALGORITHM = "HS256"
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(data: dict, expires_delta: timedelta = timedelta(hours=1)):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + expires_delta
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(database.get_db)):
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    user = db.query(models.User).get(int(user_id))
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user
+
+
+@router.post("/register", response_model=schemas.UserOut)
+def register(user: schemas.UserCreate, db: Session = Depends(database.get_db)):
+    if db.query(models.User).filter(models.User.email == user.email).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    db_user = models.User(email=user.email,
+                          hashed_password=get_password_hash(user.password),
+                          display_name=user.display_name)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.post("/login", response_model=schemas.Token)
+def login(form: schemas.UserCreate, db: Session = Depends(database.get_db)):
+    user = db.query(models.User).filter(models.User.email == form.email).first()
+    if not user or not verify_password(form.password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect email or password")
+    token = create_access_token({"sub": str(user.id)})
+    return {"access_token": token}

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./pool.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+from . import models, database
+from .auth import router as auth_router
+from .matches import router as match_router
+from .robot import router as robot_router
+
+models.Base.metadata.create_all(bind=database.engine)
+
+app = FastAPI()
+
+app.include_router(auth_router)
+app.include_router(match_router)
+app.include_router(robot_router)

--- a/backend/matches.py
+++ b/backend/matches.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+import json
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas, database
+from .auth import get_current_user
+from main.core.billiard_api import compute_shot
+from main.communicate import tcp_communicate
+
+router = APIRouter(prefix="/matches", tags=["matches"])
+
+
+@router.post("", response_model=schemas.MatchOut)
+def create_match(match_in: schemas.MatchCreate,
+                 db: Session = Depends(database.get_db),
+                 user: models.User = Depends(get_current_user)):
+    match = models.Match(user_id=user.id,
+                         mode=match_in.mode,
+                         difficulty=match_in.difficulty,
+                         start_time=datetime.utcnow())
+    db.add(match)
+    db.commit()
+    db.refresh(match)
+    return match
+
+
+@router.post("/{match_id}/rounds", response_model=schemas.RoundOut)
+def create_round(match_id: int,
+                 round_in: schemas.RoundCreate,
+                 db: Session = Depends(database.get_db),
+                 user: models.User = Depends(get_current_user)):
+    match = db.query(models.Match).filter(models.Match.id == match_id,
+                                          models.Match.user_id == user.id).first()
+    if not match:
+        raise HTTPException(status_code=404, detail="Match not found")
+    rnd = models.Round(match_id=match.id,
+                       turn=round_in.turn,
+                       shot_result=round_in.shot_result,
+                       state_json=round_in.state_json)
+    db.add(rnd)
+    db.commit()
+    db.refresh(rnd)
+
+    if round_in.turn == models.Turn.player:
+        try:
+            state = json.loads(round_in.state_json)
+            info = compute_shot(state['cue'], state['target'], state.get('others', []))
+            if info:
+                tcp_communicate.send_shot(info['angle_deg'], 0.8, 0.0)
+                ai_rnd = models.Round(match_id=match.id,
+                                      turn=models.Turn.ai,
+                                      shot_result=models.ShotResult.miss,
+                                      state_json=round_in.state_json)
+                db.add(ai_rnd)
+                db.commit()
+        except Exception:
+            pass
+    return rnd
+
+
+@router.get("/{match_id}", response_model=schemas.MatchOut)
+def get_match(match_id: int,
+              db: Session = Depends(database.get_db),
+              user: models.User = Depends(get_current_user)):
+    match = db.query(models.Match).filter(models.Match.id == match_id,
+                                          models.Match.user_id == user.id).first()
+    if not match:
+        raise HTTPException(status_code=404, detail="Match not found")
+    return match

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,64 @@
+from sqlalchemy import Column, Integer, String, DateTime, Enum, ForeignKey
+from sqlalchemy.orm import relationship
+import enum
+from .database import Base
+
+
+class MatchMode(str, enum.Enum):
+    nine = "9"
+    ten = "10"
+
+
+class Difficulty(str, enum.Enum):
+    easy = "easy"
+    medium = "medium"
+    hard = "hard"
+
+
+class Turn(str, enum.Enum):
+    player = "player"
+    ai = "ai"
+
+
+class ShotResult(str, enum.Enum):
+    pocket = "pocket"
+    miss = "miss"
+    foul = "foul"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    display_name = Column(String, nullable=False)
+
+    matches = relationship("Match", back_populates="user")
+
+
+class Match(Base):
+    __tablename__ = "matches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    mode = Column(Enum(MatchMode), nullable=False)
+    difficulty = Column(Enum(Difficulty), nullable=False)
+    start_time = Column(DateTime)
+    end_time = Column(DateTime)
+    result = Column(String)
+
+    user = relationship("User", back_populates="matches")
+    rounds = relationship("Round", back_populates="match")
+
+
+class Round(Base):
+    __tablename__ = "rounds"
+
+    id = Column(Integer, primary_key=True, index=True)
+    match_id = Column(Integer, ForeignKey("matches.id"))
+    turn = Column(Enum(Turn), nullable=False)
+    shot_result = Column(Enum(ShotResult))
+    state_json = Column(String)
+
+    match = relationship("Match", back_populates="rounds")

--- a/backend/robot.py
+++ b/backend/robot.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from .auth import get_current_user
+from main.communicate import tcp_communicate
+
+router = APIRouter(prefix="/robot", tags=["robot"])
+
+robot_state = {"status": "idle", "last_error": ""}
+
+
+class ShotCmd(BaseModel):
+    angle: float
+    power: float
+    spin: float = 0.0
+
+
+@router.post("/shoot")
+def shoot(cmd: ShotCmd, user=Depends(get_current_user)):
+    robot_state["status"] = "busy"
+    success, resp = tcp_communicate.send_shot(cmd.angle, cmd.power, cmd.spin)
+    if success:
+        robot_state["status"] = "idle"
+        return {"success": True, "response": resp}
+    else:
+        robot_state["status"] = "error"
+        robot_state["last_error"] = resp
+        return {"success": False, "response": resp}
+
+
+@router.get("/status")
+def status():
+    return robot_state
+
+
+@router.post("/stop")
+def stop(user=Depends(get_current_user)):
+    success, resp = tcp_communicate.send_stop()
+    if success:
+        robot_state["status"] = "idle"
+    else:
+        robot_state["status"] = "error"
+        robot_state["last_error"] = resp
+    return {"success": success, "response": resp}

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, EmailStr
+from .models import MatchMode, Difficulty, Turn, ShotResult
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+    display_name: str
+
+class UserOut(BaseModel):
+    id: int
+    email: EmailStr
+    display_name: str
+    class Config:
+        orm_mode = True
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+class MatchCreate(BaseModel):
+    mode: MatchMode
+    difficulty: Difficulty
+
+class RoundCreate(BaseModel):
+    turn: Turn
+    shot_result: ShotResult
+    state_json: str
+
+class RoundOut(BaseModel):
+    id: int
+    turn: Turn
+    shot_result: ShotResult
+    state_json: str
+    class Config:
+        orm_mode = True
+
+class MatchOut(BaseModel):
+    id: int
+    mode: MatchMode
+    difficulty: Difficulty
+    start_time: Optional[datetime]
+    end_time: Optional[datetime]
+    result: Optional[str]
+    rounds: List[RoundOut] = []
+    class Config:
+        orm_mode = True

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pool-frontend",
+  "private": true,
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "axios": "^1.6.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Pool Robot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="../src/index.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+import Login from './Login';
+import Dashboard from './Dashboard';
+import MatchPlay from './MatchPlay';
+
+export default function App() {
+  const [token, setToken] = useState(null);
+  const [matchId, setMatchId] = useState(null);
+
+  if (!token) return <Login onLogin={setToken} />;
+  if (!matchId) return <Dashboard token={token} onStart={setMatchId} />;
+  return <MatchPlay token={token} />;
+}

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { startMatch } from './api';
+
+export default function Dashboard({ token, onStart }) {
+  const create = async () => {
+    const res = await startMatch(token, { mode: '9', difficulty: 'easy' });
+    onStart(res.data.id);
+  };
+  return <button onClick={create}>Start Match</button>;
+}

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import { login } from './api';
+
+export default function Login({ onLogin }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    const res = await login(email, password);
+    onLogin(res.data.access_token);
+  };
+
+  return (
+    <form onSubmit={submit}>
+      <input value={email} onChange={e=>setEmail(e.target.value)} placeholder="email" />
+      <input type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="password" />
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/frontend/src/MatchPlay.jsx
+++ b/frontend/src/MatchPlay.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { shoot } from './api';
+
+export default function MatchPlay({ token }) {
+  const [angle, setAngle] = useState(45);
+  const [power, setPower] = useState(0.8);
+
+  const send = () => {
+    shoot(token, angle, power);
+  };
+
+  return (
+    <div>
+      <div>Angle: <input type="number" value={angle} onChange={e=>setAngle(parseFloat(e.target.value))} /></div>
+      <div>Power: <input type="number" step="0.1" value={power} onChange={e=>setPower(parseFloat(e.target.value))} /></div>
+      <button onClick={send}>Shoot</button>
+    </div>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:8000',
+});
+
+export function login(email, password) {
+  return api.post('/auth/login', { email, password });
+}
+
+export function register(data) {
+  return api.post('/auth/register', data);
+}
+
+export function startMatch(token, data) {
+  return api.post('/matches', data, { headers: { Authorization: `Bearer ${token}` }});
+}
+
+export function shoot(token, angle, power, spin=0) {
+  return api.post('/robot/shoot', { angle, power, spin }, { headers: { Authorization: `Bearer ${token}` }});
+}
+
+export default api;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/main/communicate/tcp_communicate.py
+++ b/main/communicate/tcp_communicate.py
@@ -1,12 +1,14 @@
 import socket
 import time
+from communicate.tcp import create_connection, send_message, receive_message
+from configs.setting import HOST, PORT
 
 
 def connect(HOST, PORT, input):
-    
+
     MAX_RETRIES = 3         # 最多重試次數
     RETRY_DELAY = 5         # 每次重試間隔 (秒)
-    
+
     attempt = 0
     while attempt < MAX_RETRIES:
         try:
@@ -40,8 +42,39 @@ def connect(HOST, PORT, input):
                 time.sleep(RETRY_DELAY)
             else:
                 print("已達最大重試次數，程式結束。")
-                
-                
+
+
+def send_shot(angle: float, power: float, spin: float = 0.0,
+              host: str = HOST, port: int = PORT):
+    """Send a shot command to the robot via TCP."""
+    payload = f"{angle:.2f},{power:.2f},{spin:.2f}"
+    sock = create_connection(host, port)
+    if sock is None:
+        return False, "connection failed"
+    try:
+        send_message(sock, payload)
+        resp = receive_message(sock)
+        return True, resp
+    except Exception as e:
+        return False, str(e)
+    finally:
+        sock.close()
+
+
+def send_stop(host: str = HOST, port: int = PORT):
+    """Send emergency stop to robot."""
+    sock = create_connection(host, port)
+    if sock is None:
+        return False, "connection failed"
+    try:
+        send_message(sock, "STOP")
+        resp = receive_message(sock)
+        return True, resp
+    except Exception as e:
+        return False, str(e)
+    finally:
+        sock.close()
+
+
 if __name__ == '__main__':
-    connect(HOST = '192.168.0.155',PORT = 4000,input = '')  # 傳送 '100' 給伺服器
-    
+    connect(HOST='192.168.0.155', PORT=4000, input='')

--- a/main/main.py
+++ b/main/main.py
@@ -2,7 +2,7 @@ from vision.yoloball import capture_balls
 from communicate.tcp import create_connection, send_message, receive_message
 import socket
 from configs.setting import HOST, PORT
-from run_shot import plan_shot_from_json
+from plan_shot import plan_shot_from_json
 
 import time
 import math 

--- a/main/plan_shot.py
+++ b/main/plan_shot.py
@@ -1,0 +1,120 @@
+"""
+將 YOLO 偵測 JSON (cm) 轉成 compute_shot() 輸入，
+回傳 angle_deg + cue 座標，可選擇 --show 圖形化。
+
+用法：
+    python run_shot.py <json> [target_id|'min'] [--show]
+
+參數說明
+---------
+<json>      ：YOLO 偵測結果路徑
+[target_id] ：
+    不輸入      → 取 conf 最高的非 0 號球
+    整數 n      → 指定球號 n
+    'min'       → 自動選擇除了 0 以外編號最小的球
+--show      ：顯示圖形化路徑
+
+此版本採 **作法 A**：
+  ‑ 所有錯誤在 `plan_shot_from_json()` 內部捕捉並回傳 `None`，
+  ‑ 呼叫端只需判斷是否為 `None`。
+"""
+import json
+import argparse
+from typing import Optional, Tuple, List, Union
+
+from core.billiard_api import compute_shot         # 需 core/__init__.py
+import gui.visualize as visualize                  # 需 gui/__init__.py
+
+
+# ──────────────── 工具 ────────────────
+
+def cm2m(x_cm: float, y_cm: float) -> Tuple[float, float]:
+    """cm → m"""
+    return x_cm / 100.0, y_cm / 100.0
+
+
+def plan_shot_from_json(
+    json_path: str,
+    target_id: Optional[Union[int, str]] = None,
+    show: bool = False,
+) -> Optional[Tuple[float, Tuple[float, float]]]:
+    """讀取偵測結果並規劃擊球
+
+    成功 → (angle_deg, cue_xy)
+    失敗 → None（並印出錯誤訊息）
+    """
+    try:
+        # --- 讀檔 ---
+        with open(json_path, "r", encoding="utf-8") as f:
+            raw_balls = json.load(f)["balls"]
+
+        balls = [b for b in raw_balls if b["conf"] >= 0.30]
+        if not balls:
+            raise RuntimeError("JSON 內沒有信心值 ≥0.30 的球")
+
+        # --- cue 球 ---
+        cue_b = next(b for b in balls if b["type"] == "0")
+
+        # --- 目標球邏輯 ---
+        if target_id is None:
+            # conf 最高
+            tgt_b = max((b for b in balls if b["type"] != "0"), key=lambda b: b["conf"])
+        elif target_id == "min":
+            tgt_b = min((b for b in balls if b["type"] != "0"), key=lambda b: int(b["type"]))
+        else:
+            tgt_b = next((b for b in balls if b["type"] == str(target_id)), None)
+            if tgt_b is None:
+                raise RuntimeError(f"找不到球號 {target_id}")
+
+        blk_bs: List[dict] = [b for b in balls if b not in (cue_b, tgt_b)]
+
+        # --- cm → m ---
+        cue_xy = cm2m(cue_b["cx_cm"], cue_b["cy_cm"])
+        target = cm2m(tgt_b["cx_cm"], tgt_b["cy_cm"])
+        blocks = [cm2m(b["cx_cm"], b["cy_cm"]) for b in blk_bs]
+
+        # --- 求解 ---
+        info = compute_shot(cue_xy, target, blocks)
+        if info is None:
+            raise RuntimeError("無可行路徑 (compute_shot 回傳 None)")
+
+        if show:
+            visualize.show(cue_xy, target, blocks, info)
+
+        return info["angle_deg"], cue_xy
+
+    except Exception as e:
+        print("[plan_shot] 失敗：", e)
+        return None
+
+
+# ──────────────── CLI ────────────────
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("json", help="YOLO 偵測結果 .json 路徑")
+    ap.add_argument("id", nargs="?", help="目標球號；輸入 'min' 取最小球")
+    ap.add_argument("--show", action="store_true", help="顯示圖形化路徑")
+    args = ap.parse_args()
+
+    # 解析目標參數
+    if args.id is None:
+        target_param: Optional[Union[int, str]] = None
+    elif args.id.lower() == "min":
+        target_param = "min"
+    else:
+        try:
+            target_param = int(args.id)
+        except ValueError:
+            print(f"[run_shot] 提供的球號 {args.id!r} 不是整數，也不是 'min'")
+            exit(1)
+
+    # 呼叫函式 ─ 成功回 (angle, cue)；失敗回 None
+    result = plan_shot_from_json(args.json, target_param, show=args.show)
+
+    if result is None:
+        print("→ None")
+    else:
+        angle_deg, cue_xy = result
+        print(
+            f"→ angle_deg = {angle_deg:.2f}°, cue = ({cue_xy[0]:.3f} m, {cue_xy[1]:.3f} m)"
+        )

--- a/main/run_shot.py
+++ b/main/run_shot.py
@@ -1,120 +1,15 @@
-"""
-將 YOLO 偵測 JSON (cm) 轉成 compute_shot() 輸入，
-回傳 angle_deg + cue 座標，可選擇 --show 圖形化。
-
-用法：
-    python run_shot.py <json> [target_id|'min'] [--show]
-
-參數說明
----------
-<json>      ：YOLO 偵測結果路徑
-[target_id] ：
-    不輸入      → 取 conf 最高的非 0 號球
-    整數 n      → 指定球號 n
-    'min'       → 自動選擇除了 0 以外編號最小的球
---show      ：顯示圖形化路徑
-
-此版本採 **作法 A**：
-  ‑ 所有錯誤在 `plan_shot_from_json()` 內部捕捉並回傳 `None`，
-  ‑ 呼叫端只需判斷是否為 `None`。
-"""
-import json
 import argparse
-from typing import Optional, Tuple, List, Union
+from communicate import tcp_communicate
 
-from core.billiard_api import compute_shot         # 需 core/__init__.py
-import gui.visualize as visualize                  # 需 gui/__init__.py
-
-
-# ──────────────── 工具 ────────────────
-
-def cm2m(x_cm: float, y_cm: float) -> Tuple[float, float]:
-    """cm → m"""
-    return x_cm / 100.0, y_cm / 100.0
-
-
-def plan_shot_from_json(
-    json_path: str,
-    target_id: Optional[Union[int, str]] = None,
-    show: bool = False,
-) -> Optional[Tuple[float, Tuple[float, float]]]:
-    """讀取偵測結果並規劃擊球
-
-    成功 → (angle_deg, cue_xy)
-    失敗 → None（並印出錯誤訊息）
-    """
-    try:
-        # --- 讀檔 ---
-        with open(json_path, "r", encoding="utf-8") as f:
-            raw_balls = json.load(f)["balls"]
-
-        balls = [b for b in raw_balls if b["conf"] >= 0.30]
-        if not balls:
-            raise RuntimeError("JSON 內沒有信心值 ≥0.30 的球")
-
-        # --- cue 球 ---
-        cue_b = next(b for b in balls if b["type"] == "0")
-
-        # --- 目標球邏輯 ---
-        if target_id is None:
-            # conf 最高
-            tgt_b = max((b for b in balls if b["type"] != "0"), key=lambda b: b["conf"])
-        elif target_id == "min":
-            tgt_b = min((b for b in balls if b["type"] != "0"), key=lambda b: int(b["type"]))
-        else:
-            tgt_b = next((b for b in balls if b["type"] == str(target_id)), None)
-            if tgt_b is None:
-                raise RuntimeError(f"找不到球號 {target_id}")
-
-        blk_bs: List[dict] = [b for b in balls if b not in (cue_b, tgt_b)]
-
-        # --- cm → m ---
-        cue_xy = cm2m(cue_b["cx_cm"], cue_b["cy_cm"])
-        target = cm2m(tgt_b["cx_cm"], tgt_b["cy_cm"])
-        blocks = [cm2m(b["cx_cm"], b["cy_cm"]) for b in blk_bs]
-
-        # --- 求解 ---
-        info = compute_shot(cue_xy, target, blocks)
-        if info is None:
-            raise RuntimeError("無可行路徑 (compute_shot 回傳 None)")
-
-        if show:
-            visualize.show(cue_xy, target, blocks, info)
-
-        return info["angle_deg"], cue_xy
-
-    except Exception as e:
-        print("[plan_shot] 失敗：", e)
-        return None
-
-
-# ──────────────── CLI ────────────────
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser()
-    ap.add_argument("json", help="YOLO 偵測結果 .json 路徑")
-    ap.add_argument("id", nargs="?", help="目標球號；輸入 'min' 取最小球")
-    ap.add_argument("--show", action="store_true", help="顯示圖形化路徑")
-    args = ap.parse_args()
+    parser = argparse.ArgumentParser(description="Send a shot command to the robot")
+    parser.add_argument("angle", type=float, help="shot angle in degrees")
+    parser.add_argument("power", type=float, help="normalized shot power (0-1)")
+    parser.add_argument("spin", type=float, nargs="?", default=0.0, help="optional spin value")
+    args = parser.parse_args()
 
-    # 解析目標參數
-    if args.id is None:
-        target_param: Optional[Union[int, str]] = None
-    elif args.id.lower() == "min":
-        target_param = "min"
+    success, resp = tcp_communicate.send_shot(args.angle, args.power, args.spin)
+    if success:
+        print(f"Robot response: {resp}")
     else:
-        try:
-            target_param = int(args.id)
-        except ValueError:
-            print(f"[run_shot] 提供的球號 {args.id!r} 不是整數，也不是 'min'")
-            exit(1)
-
-    # 呼叫函式 ─ 成功回 (angle, cue)；失敗回 None
-    result = plan_shot_from_json(args.json, target_param, show=args.show)
-
-    if result is None:
-        print("→ None")
-    else:
-        angle_deg, cue_xy = result
-        print(
-            f"→ angle_deg = {angle_deg:.2f}°, cue = ({cue_xy[0]:.3f} m, {cue_xy[1]:.3f} m)"
-        )
+        print(f"Failed to send shot: {resp}")


### PR DESCRIPTION
## Summary
- Implement FastAPI backend with auth, matches, rounds and robot control endpoints
- Add TCP shot/stop helpers and CLI run_shot command
- Provide minimal React frontend with login, dashboard and match play

## Testing
- `pytest` *(fails: SystemExit: 找不到影像 photo_000.jpg)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1974dfcc832e81b1996c9722c9db