### PR TITLE
Fix relative imports in main package

### DIFF
--- a/main/communicate/tcp_communicate.py
+++ b/main/communicate/tcp_communicate.py
@@ -1,7 +1,7 @@
 import socket
 import time
-from communicate.tcp import create_connection, send_message, receive_message
-from configs.setting import HOST, PORT
+from .tcp import create_connection, send_message, receive_message
+from ..configs.setting import HOST, PORT
 
 
 def connect(HOST, PORT, input):

--- a/main/main.py
+++ b/main/main.py
@@ -1,5 +1,5 @@
 from vision.yoloball import capture_balls
-from communicate.tcp import create_connection, send_message, receive_message
+from .communicate.tcp import create_connection, send_message, receive_message
 import socket
 from configs.setting import HOST, PORT
 from plan_shot import plan_shot_from_json

--- a/main/run_shot.py
+++ b/main/run_shot.py
@@ -1,5 +1,5 @@
 import argparse
-from communicate import tcp_communicate
+from .communicate import tcp_communicate
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Send a shot command to the robot")


### PR DESCRIPTION
## Summary
- use relative import in `main/communicate/tcp_communicate.py`
- update `main/main.py` and `main/run_shot.py` to import tcp_communicate relatively

## Testing
- `python -m main.run_shot 10 0.5` *(fails to connect, but runs without ModuleNotFoundError)*
- `uvicorn backend.main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_68bb8e1cbbf0832ebce4592164041de1