### PR TITLE
Add user registration page and login fixes

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -58,7 +58,7 @@ def register(user: schemas.UserCreate, db: Session = Depends(database.get_db)):
 
 
 @router.post("/login", response_model=schemas.Token)
-def login(form: schemas.UserCreate, db: Session = Depends(database.get_db)):
+def login(form: schemas.UserLogin, db: Session = Depends(database.get_db)):
     user = db.query(models.User).filter(models.User.email == form.email).first()
     if not user or not verify_password(form.password, user.hashed_password):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect email or password")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -8,6 +8,10 @@ class UserCreate(BaseModel):
     password: str
     display_name: str
 
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
 class UserOut(BaseModel):
     id: int
     email: EmailStr

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
 import Login from './Login';
+import Register from './Register';
 import Dashboard from './Dashboard';
 import MatchPlay from './MatchPlay';
 
 export default function App() {
   const [token, setToken] = useState(null);
   const [matchId, setMatchId] = useState(null);
+  const [mode, setMode] = useState('login');
 
-  if (!token) return <Login onLogin={setToken} />;
+  if (!token) {
+    if (mode === 'login') {
+      return <Login onLogin={setToken} onSwitch={() => setMode('register')} />;
+    }
+    return <Register onRegister={setToken} onSwitch={() => setMode('login')} />;
+  }
   if (!matchId) return <Dashboard token={token} onStart={setMatchId} />;
   return <MatchPlay token={token} />;
 }

--- a/frontend/src/Register.jsx
+++ b/frontend/src/Register.jsx
@@ -1,18 +1,20 @@
 import React, { useState } from 'react';
-import { login } from './api';
+import { register as apiRegister, login } from './api';
 
-export default function Login({ onLogin, onSwitch }) {
+export default function Register({ onRegister, onSwitch }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [displayName, setDisplayName] = useState('');
   const [error, setError] = useState(null);
 
   const submit = async e => {
     e.preventDefault();
     try {
+      await apiRegister({ email, password, display_name: displayName });
       const res = await login(email, password);
-      onLogin(res.data.access_token);
+      onRegister(res.data.access_token);
     } catch (err) {
-      setError(err.response?.data?.detail || 'Login failed');
+      setError(err.response?.data?.detail || 'Registration failed');
     }
   };
 
@@ -21,8 +23,9 @@ export default function Login({ onLogin, onSwitch }) {
       {error && <p>{error}</p>}
       <input value={email} onChange={e => setEmail(e.target.value)} placeholder="email" />
       <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="password" />
-      <button type="submit">Login</button>
-      <button type="button" onClick={onSwitch}>Register</button>
+      <input value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder="display name" />
+      <button type="submit">Register</button>
+      <button type="button" onClick={onSwitch}>Back to Login</button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- Add Register component to allow user sign-ups and toggle from Login
- Fix authentication schema with dedicated UserLogin model
- Wire frontend between login and register screens with navigation buttons

## Testing
- `npm test` *(fails: Missing script 'test')*
- `pytest` *(fails: ImportError: libGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a8775ec832e8ddf6b0ec7a2b391