### PR TITLE
feat: add auto shot pipeline

### DIFF
--- a/backend/robot.py
+++ b/backend/robot.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel
 
 from .auth import get_current_user
 from main.communicate import tcp_communicate
+from main.vision.yoloball import capture_balls
+from main.plan_shot import plan_shot_from_json
 
 router = APIRouter(prefix="/robot", tags=["robot"])
 
@@ -26,6 +28,38 @@ def shoot(cmd: ShotCmd, user=Depends(get_current_user)):
         robot_state["status"] = "error"
         robot_state["last_error"] = resp
         return {"success": False, "response": resp}
+
+
+@router.post("/auto")
+def auto_shoot(user=Depends(get_current_user)):
+    """Run full pipeline: capture → plan → shoot."""
+    robot_state["status"] = "busy"
+    try:
+        json_path, _ = capture_balls(
+            wait_sec=3, show=False, intrinsics_path="main/vision/intrinsics.yaml"
+        )
+        if not json_path:
+            raise RuntimeError("capture failed")
+
+        result = plan_shot_from_json(json_path, "min", show=False)
+        if result is None:
+            raise RuntimeError("planning failed")
+
+        angle_deg, _ = result
+        power = 0.8  # default power
+
+        success, resp = tcp_communicate.send_shot(angle_deg, power, 0.0)
+        if success:
+            robot_state["status"] = "idle"
+            return {"success": True, "angle": angle_deg, "power": power, "response": resp}
+        else:
+            robot_state["status"] = "error"
+            robot_state["last_error"] = resp
+            return {"success": False, "response": resp}
+    except Exception as e:
+        robot_state["status"] = "error"
+        robot_state["last_error"] = str(e)
+        return {"success": False, "response": str(e)}
 
 
 @router.get("/status")

--- a/frontend/src/MatchPlay.jsx
+++ b/frontend/src/MatchPlay.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { shoot } from './api';
+import { shoot, autoShoot } from './api';
 
 export default function MatchPlay({ token }) {
   const [angle, setAngle] = useState(45);
@@ -9,11 +9,16 @@ export default function MatchPlay({ token }) {
     shoot(token, angle, power);
   };
 
+  const auto = () => {
+    autoShoot(token);
+  };
+
   return (
     <div>
       <div>Angle: <input type="number" value={angle} onChange={e=>setAngle(parseFloat(e.target.value))} /></div>
       <div>Power: <input type="number" step="0.1" value={power} onChange={e=>setPower(parseFloat(e.target.value))} /></div>
       <button onClick={send}>Shoot</button>
+      <button onClick={auto}>Auto Shoot</button>
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,4 +20,8 @@ export function shoot(token, angle, power, spin=0) {
   return api.post('/robot/shoot', { angle, power, spin }, { headers: { Authorization: `Bearer ${token}` }});
 }
 
+export function autoShoot(token) {
+  return api.post('/robot/auto', {}, { headers: { Authorization: `Bearer ${token}` }});
+}
+
 export default api;


### PR DESCRIPTION
## Summary
- add backend `/robot/auto` endpoint to capture, plan, and shoot automatically
- wire frontend API and MatchPlay with an Auto Shoot button

## Testing
- `python -m py_compile backend/robot.py`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc20605178832eb54cfaf9fc473444