### PR TITLE
Ensure backend auth runs on Python 3.9

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timedelta
-from typing import Dict
+from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
@@ -29,7 +29,9 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
-def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+def create_access_token(
+    data: dict, expires_delta: Optional[timedelta] = None
+) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
     to_encode.update({"exp": expire})
@@ -58,7 +60,7 @@ async def get_current_user(token: str = Depends(oauth2_scheme)):
     credentials_exception = HTTPException(status_code=401, detail="Could not validate credentials")
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        email: str | None = payload.get("sub")
+        email: Optional[str] = payload.get("sub")
         if email is None or email not in fake_users_db:
             raise credentials_exception
     except JWTError:


### PR DESCRIPTION
## Summary
- replace PEP 604 union syntax in backend auth module with Optional for broader Python compatibility

## Testing
- `python -m py_compile backend/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68bfe5d59638832ea9613247275b5101